### PR TITLE
Add fallback to img tag when loaded in browser

### DIFF
--- a/src/components/img-loader.ts
+++ b/src/components/img-loader.ts
@@ -186,7 +186,9 @@ export class ImgLoader implements OnInit {
 
       // set it's src
       this._renderer.setElementAttribute(this.element, 'src', imageUrl);
-
+      if(this.fallbackUrl){
+          this._renderer.setElementAttribute(this.element, 'onerror', 'this.src=\'' + this.fallbackUrl + '\'');
+      }
     } else {
 
       // Not using <img> tag


### PR DESCRIPTION
This PR adds support for browser when there's an error loading the image.

Ibby, a few considerations:

Stuff I tried and didn't work:
-  `this._element.onerror = function() { }`
-  `this._element.nativeElement.onerror = function() { }`
-  `this._renderer.listen(this.element, 'onerror', function() { });` 

Regarding when the user uses `useImg` as false, apparently everything works as expected already.