### PR TITLE
Remove the platform.ready for the Observable

### DIFF
--- a/src/providers/image-loader.ts
+++ b/src/providers/image-loader.ts
@@ -80,24 +80,23 @@ export class ImageLoader {
     private fileTransfer: FileTransfer,
     private platform: Platform
   ) {
- Observable.fromEvent(document, 'deviceready').first().subscribe(res => {
-      if (!platform.is('cordova')) {
-        // we are running on a browser, or using livereload
-        // plugin will not function in this case
-        this.isInit = true;
-        this.throwWarning('You are running on a browser or using livereload, IonicImageLoader will not function, falling back to browser loading.');
-      } else {
-
-          if (this.nativeAvailable) {
-            this.initCache();
-          } else {
-            // we are running on a browser, or using livereload
-            // plugin will not function in this case
-            this.isInit = true;
-            this.throwWarning('You are running on a browser or using livereload, IonicImageLoader will not function, falling back to browser loading.');
-          }
-      }
-    });
+    if (!platform.is('cordova')) {
+      // we are running on a browser, or using livereload
+      // plugin will not function in this case
+      this.isInit = true;
+      this.throwWarning('You are running on a browser or using livereload, IonicImageLoader will not function, falling back to browser loading.');
+    } else {
+      Observable.fromEvent(document, 'deviceready').first().subscribe(res => {
+        if (this.nativeAvailable) {
+          this.initCache();
+        } else {
+          // we are running on a browser, or using livereload
+          // plugin will not function in this case
+          this.isInit = true;
+          this.throwWarning('You are running on a browser or using livereload, IonicImageLoader will not function, falling back to browser loading.');
+        }
+      });
+    }
   }
 
   /**
@@ -356,7 +355,7 @@ export class ImageLoader {
       .then(files => Promise.all(files.map(this.addFileToIndex.bind(this))))
       .then(() => {
         // Sort items by date. Most recent to oldest.
-        this.cacheIndex = this.cacheIndex.sort((a: IndexItem, b: IndexItem): number => a>b?-1:a<b?1:0);
+        this.cacheIndex = this.cacheIndex.sort((a: IndexItem, b: IndexItem): number => a > b ? -1 : a < b ? 1 : 0);
         this.indexed = true;
         return Promise.resolve();
       })

--- a/src/providers/image-loader.ts
+++ b/src/providers/image-loader.ts
@@ -80,14 +80,14 @@ export class ImageLoader {
     private fileTransfer: FileTransfer,
     private platform: Platform
   ) {
-    platform.ready().then(() => {
+ Observable.fromEvent(document, 'deviceready').first().subscribe(res => {
       if (!platform.is('cordova')) {
         // we are running on a browser, or using livereload
         // plugin will not function in this case
         this.isInit = true;
         this.throwWarning('You are running on a browser or using livereload, IonicImageLoader will not function, falling back to browser loading.');
       } else {
-        Observable.fromEvent(document, 'deviceready').first().subscribe(res => {
+
           if (this.nativeAvailable) {
             this.initCache();
           } else {
@@ -96,7 +96,6 @@ export class ImageLoader {
             this.isInit = true;
             this.throwWarning('You are running on a browser or using livereload, IonicImageLoader will not function, falling back to browser loading.');
           }
-        })
       }
     });
   }


### PR DESCRIPTION
Removing the platform.ready event for faster loading and really better behavior in bad network areas. (As explained, sometimes, the platform.ready event is never fired, but it is hard to find why)