### PR TITLE
replace FileTransfer plugin with HttpClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+<a name="4.2.2"></a>
+## [4.2.2](https://github.com/zyra/ionic-image-loader/compare/v4.2.1...v4.2.2) (2018-01-13)
+
+
+### Compatibility
+
+* **provider:** use Angular HttpClient instead of deprecated FileTransfer plugin, closes ([#124](https://github.com/zyra/ionic-image-loader/issues/124))
+
+
 <a name="4.2.1"></a>
 ## [4.2.1](https://github.com/zyra/ionic-image-loader/compare/v4.2.0...v4.2.1) (2017-09-07)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 [![npm](https://img.shields.io/npm/dm/ionic-image-loader.svg)](https://www.npmjs.com/package/ionic-image-loader)
 
 # Ionic Image Loader
-**Ionic** Module that loads images in a native background thread and caches them for later use. Uses `cordova-plugin-file` and `cordova-plugin-file-transfer` via [`ionic-native`](https://github.com/driftyco/ionic-native) wrappers.
+**Ionic** Module that loads images in a background thread and caches them for later use. Uses `HttpClient` from `Angular 4+`, and `cordova-plugin-file` via [`ionic-native`](https://github.com/driftyco/ionic-native) wrappers.
+
 
 ## Features
 - Downloads images via a **native thread**. Images will download faster and they will not use the Webview's resources.
@@ -36,9 +37,6 @@ npm install --save ionic-image-loader
 ```
 npm i --save @ionic-native/file
 ionic cordova plugin add cordova-plugin-file
-
-npm i --save @ionic-native/file-transfer
-ionic cordova plugin add cordova-plugin-file-transfer
 ```
 
 #### 3. Import `IonicImageLoader` module
@@ -267,13 +265,12 @@ Example:
 this.imageLoaderConfig.enableFallbackAsPlaceholder(true);
 ```
 ---
-#### setFileTransferOptions(options: any)
-Set options for FileTransfer plugin to use. If you would like to set a value for the `trustAllHosts` param, you can add it to the options object.
+#### setHttpRequestOptions(options: any)
+Set options for HttpClient to use.
 
 Example:
 ```ts
-this.imageLoaderConfig.setFileTransferOptions({
-  trustAllHosts: true, // defaults to false
+this.imageLoaderConfig.setHttpRequestOptions({
   headers: {
     Authorization: 'Basic dGVzdHVzZXJuYW1lOnRlc3RwYXNzd29yZA=='
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ionic-image-loader",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -97,12 +97,6 @@
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/@ionic-native/file/-/file-4.3.3.tgz",
       "integrity": "sha512-r273zw1gkgGTmlapyJnh31Yemt1P8u1CnTtiZGr3oC/BdlSvLppR7ONW7KbsAxA31UIDAXG+mXP3EqEP2AtVvw==",
-      "dev": true
-    },
-    "@ionic-native/file-transfer": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@ionic-native/file-transfer/-/file-transfer-4.3.3.tgz",
-      "integrity": "sha512-NRs2Nl2+Zzk4tVXESssV9DcYKvzmgUn6e1+MwxJ+QmVoQNmeSPNRnFSQoqE+IEkCjENjK1Yg0XJFfcDBpyCp6Q==",
       "dev": true
     },
     "JSONStream": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ionic-image-loader",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "Ionic Component and Service to load images in a background thread and cache them for later use",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -39,7 +39,6 @@
     "@angular/platform-browser-dynamic": "4.4.4",
     "@ionic-native/core": "^4.3.3",
     "@ionic-native/file": "^4.3.3",
-    "@ionic-native/file-transfer": "^4.3.3",
     "conventional-changelog-cli": "1.3.4",
     "ionic-angular": "3.8.0",
     "rxjs": "5.4.3",
@@ -47,7 +46,6 @@
     "zone.js": "0.8.18"
   },
   "peerDependencies": {
-    "@ionic-native/file": "^4.0.0",
-    "@ionic-native/file-transfer": "^4.0.0"
+    "@ionic-native/file": "^4.0.0"
   }
 }

--- a/src/image-loader.module.ts
+++ b/src/image-loader.module.ts
@@ -1,17 +1,18 @@
-import { NgModule, ModuleWithProviders } from '@angular/core';
+import { ModuleWithProviders, NgModule } from '@angular/core';
 import { ImgLoader } from './components/img-loader';
 import { ImageLoader } from './providers/image-loader';
 import { ImageLoaderConfig } from './providers/image-loader-config';
 import { IonicModule } from 'ionic-angular';
 import { File } from '@ionic-native/file';
-import { FileTransfer } from '@ionic-native/file-transfer';
+import { HttpClientModule } from '@angular/common/http';
 
 @NgModule({
   declarations: [
     ImgLoader
   ],
   imports: [
-    IonicModule
+    IonicModule,
+    HttpClientModule,
   ],
   exports: [
     ImgLoader
@@ -25,7 +26,6 @@ export class IonicImageLoader {
         ImageLoaderConfig,
         ImageLoader,
         File,
-        FileTransfer
       ]
     };
   }

--- a/src/providers/image-loader-config.ts
+++ b/src/providers/image-loader-config.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { HttpHeaders } from '@angular/common/http';
 
 @Injectable()
 export class ImageLoaderConfig {
@@ -35,9 +36,7 @@ export class ImageLoaderConfig {
 
   spinnerColor: string;
 
-  fileTransferOptions: any = {
-    trustAllHosts: false
-  };
+  httpHeaders: HttpHeaders;
 
   private _cacheDirectoryName: string = 'image-loader-cache';
 
@@ -187,11 +186,20 @@ export class ImageLoaderConfig {
   }
 
   /**
+   * Set headers options for the HttpClient transfers.
+   * @param headers
+   */
+  setHttpHeaders(headers: HttpHeaders): void {
+    this.httpHeaders = headers;
+  }
+
+  /**
    * Set options for the FileTransfer plugin
    * @param options
+   * @deprecated FileTransfer plugin removed.
    */
   setFileTransferOptions(options: { trustAllHosts: boolean; [key: string]: any; }): void {
-    this.fileTransferOptions = options;
+    // do nothing, plugin deprecated.
   }
 
 }


### PR DESCRIPTION
cordova-plugin-file-transfer deprecation #124 
Tested, working, with the most recent Ionic version on Android. This should be backwards compatible with the existing @angular/common dependency, but I don't know the meaning of `trustAllHosts`, and if it needs to be implemented again.