### PR TITLE
Added Native Http Requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm](https://img.shields.io/npm/dm/ionic-image-loader.svg)](https://www.npmjs.com/package/ionic-image-loader)
 
 # Ionic Image Loader
-**Ionic** Module that loads images in a background thread and caches them for later use. Uses `HttpClient` from `Angular 4+`, and `cordova-plugin-file` via [`ionic-native`](https://github.com/driftyco/ionic-native) wrappers.
+**Ionic** Module that loads images in a background thread and caches them for later use. Uses `cordova-plugin-file` via [`ionic-native`](https://github.com/driftyco/ionic-native) wrappers, and Ionic Native Http to add support for iOS and WKWebView
 
 
 ## Features
@@ -35,8 +35,9 @@ npm install --save ionic-image-loader
 
 #### 2. Install Required Plugins
 ```
-npm i --save @ionic-native/file
+npm i --save @ionic-native/file @ionic-native/http
 ionic cordova plugin add cordova-plugin-file
+ionic cordova plugin add cordova-plugin-advanced-http
 ```
 
 #### 3. Import `IonicImageLoader` module

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,26 +88,22 @@
       }
     },
     "@ionic-native/core": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/@ionic-native/core/-/core-4.5.2.tgz",
-      "integrity": "sha512-/Y4gvrfNqO+wpa+i41tkud6WdVawju/+c+pD1E9b8lMeWimvFfqA0/q/6+S8VWjGLKz1GrZqW9cfwJU75SC4Ug==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/@ionic-native/core/-/core-4.5.3.tgz",
+      "integrity": "sha512-Z/U9FsWTDU4sqVvTOAtUcCWECJNRkjDO8ArSrLmkWFKaCtd8gWBJNtIVNB227xPdpgc67xyoijEXY6+XaYLXxg==",
       "dev": true
     },
     "@ionic-native/file": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/@ionic-native/file/-/file-4.5.2.tgz",
-      "integrity": "sha512-6XmK6oFHpVCbZNAJffX09UWxQvwNcKMTy1qKu6iXzxRoEuhsGEls17B1COA+fr2JuPwitxGm14ZzsBXN5pPLiA==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/@ionic-native/file/-/file-4.5.3.tgz",
+      "integrity": "sha512-108OSU/U0lEbROB6CCy7yVuoNKVqIlwAy3N0MtJBK+bDRzSVEPgc2Ttu8f0GKvUki++r1Of/fY+Yv3Ut8rb9Lw==",
       "dev": true
     },
-    "JSONStream": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
-      "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
+    "@ionic-native/http": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/@ionic-native/http/-/http-4.5.3.tgz",
+      "integrity": "sha512-O6s2j5VK8H7QJvPwwW3Az4lxcf0mUl1ilQuYnvmEQ96RT6oyltE/zsmRjrAg5Gg9g+tRhTPXuDCj2Hlmi9oCag==",
+      "dev": true
     },
     "add-stream": {
       "version": "1.0.0",
@@ -383,8 +379,8 @@
       "integrity": "sha512-8MD05yN0Zb6aRsZnFX1ET+8rHWfWJk+my7ANCJZBU2mhz7TSB1fk2vZhkrwVy/PCllcTYAP/1T1NiWQ7Z01mKw==",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.2",
         "is-text-path": "1.0.1",
+        "JSONStream": "1.3.2",
         "lodash": "4.17.4",
         "meow": "3.7.0",
         "split2": "2.2.0",
@@ -657,6 +653,16 @@
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
+    },
+    "JSONStream": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
+      "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
     },
     "kind-of": {
       "version": "3.2.2",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@angular/platform-browser-dynamic": "4.4.4",
     "@ionic-native/core": "^4.3.3",
     "@ionic-native/file": "^4.3.3",
+    "@ionic-native/http": "^4.3.3",
     "conventional-changelog-cli": "1.3.4",
     "ionic-angular": "3.8.0",
     "rxjs": "5.4.3",

--- a/src/image-loader.module.ts
+++ b/src/image-loader.module.ts
@@ -3,6 +3,7 @@ import { ImgLoader } from './components/img-loader';
 import { ImageLoader } from './providers/image-loader';
 import { ImageLoaderConfig } from './providers/image-loader-config';
 import { IonicModule } from 'ionic-angular';
+import { File } from '@ionic-native/file';
 import { HTTP } from '@ionic-native/http';
 
 @NgModule({
@@ -24,6 +25,7 @@ export class IonicImageLoader {
         ImageLoaderConfig,
         ImageLoader,
         HTTP,
+        File
       ]
     };
   }

--- a/src/image-loader.module.ts
+++ b/src/image-loader.module.ts
@@ -3,16 +3,14 @@ import { ImgLoader } from './components/img-loader';
 import { ImageLoader } from './providers/image-loader';
 import { ImageLoaderConfig } from './providers/image-loader-config';
 import { IonicModule } from 'ionic-angular';
-import { File } from '@ionic-native/file';
-import { HttpClientModule } from '@angular/common/http';
+import { HTTP } from '@ionic-native/http';
 
 @NgModule({
   declarations: [
     ImgLoader
   ],
   imports: [
-    IonicModule,
-    HttpClientModule,
+    IonicModule
   ],
   exports: [
     ImgLoader
@@ -25,7 +23,7 @@ export class IonicImageLoader {
       providers: [
         ImageLoaderConfig,
         ImageLoader,
-        File,
+        HTTP,
       ]
     };
   }

--- a/src/providers/image-loader-config.ts
+++ b/src/providers/image-loader-config.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@angular/core';
-import { HttpHeaders } from '@angular/common/http';
 
 @Injectable()
 export class ImageLoaderConfig {
@@ -36,7 +35,7 @@ export class ImageLoaderConfig {
 
   spinnerColor: string;
 
-  httpHeaders: HttpHeaders;
+  httpHeaders:object;
 
   fileNameCachedWithExtension: boolean = false;
 
@@ -190,10 +189,10 @@ export class ImageLoaderConfig {
   }
 
   /**
-   * Set headers options for the HttpClient transfers.
+   * Set headers options for the Http transfers.
    * @param headers
    */
-  setHttpHeaders(headers: HttpHeaders): void {
+  setHttpHeaders(headers:object): void {
     this.httpHeaders = headers;
   }
 

--- a/src/providers/image-loader.ts
+++ b/src/providers/image-loader.ts
@@ -1,10 +1,10 @@
 import { Injectable } from '@angular/core';
 import { DirectoryEntry, File, FileEntry, FileError } from '@ionic-native/file';
-import { HttpClient } from '@angular/common/http';
 import { ImageLoaderConfig } from "./image-loader-config";
 import { Platform } from 'ionic-angular';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/operator/first';
+import {HTTP} from "@ionic-native/http";
 
 interface IndexItem {
   name: string;
@@ -74,7 +74,7 @@ export class ImageLoader {
   constructor(
     private config: ImageLoaderConfig,
     private file: File,
-    private http: HttpClient,
+    private http: HTTP,
     private platform: Platform
   ) {
     if (!platform.is('cordova')) {
@@ -252,9 +252,9 @@ export class ImageLoader {
     const fileName = this.createFileName(currentItem.imageUrl);
 
     this.http.get(currentItem.imageUrl, {
-      responseType: 'blob',
-      headers: this.config.httpHeaders,
-    }).subscribe((data: Blob) => {
+      responseType: 'blob'
+    }, this.config.httpHeaders).then((res:any) => {
+      let data:Blob = res.data;
       this.file.writeFile(localDir, fileName, data).then((file: FileEntry) => {
         if (this.shouldIndex) {
           this.addFileToIndex(file).then(this.maintainCacheSize.bind(this));


### PR DESCRIPTION
This fixes the issue where iOS WKWebView blocks cors requests so the image loader plugin does not work on iOS. This uses the Native HTTP plugin to handle the requests in the native thread. I have not been able to test this on iOS or Android. So I was wondering if someone else could test it.