### PR TITLE
fix(image-loader): queue stucks processing same url more than concurrency

### DIFF
--- a/src/providers/image-loader.ts
+++ b/src/providers/image-loader.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { DirectoryEntry, File, FileEntry, FileError } from '@ionic-native/file';
+import { File, FileEntry } from '@ionic-native/file';
 import { HttpClient } from '@angular/common/http';
 import { normalizeURL, Platform } from 'ionic-angular';
 import { ImageLoaderConfig } from './image-loader-config';

--- a/src/providers/image-loader.ts
+++ b/src/providers/image-loader.ts
@@ -248,28 +248,30 @@ export class ImageLoader {
 
     // take the first item from queue
     const currentItem: QueueItem = this.queue.splice(0, 1)[0];
+
+    // function to call when done processing this item
+    // this will reduce the processing number
+    // then will execute this function again to process any remaining items
+    const done = () => {
+      this.processing--;
+      this.processQueue();
+
+      // only delete if it's the last/unique occurrence in the queue
+      if (this.currentlyProcessing[currentItem.imageUrl] !== undefined && !this.currentlyInQueue(currentItem.imageUrl)) {
+        delete this.currentlyProcessing[currentItem.imageUrl];
+      }
+    };
+
+    const error = (e) => {
+      currentItem.reject();
+      this.throwError(e);
+      done();
+    };
+
     if (this.currentlyProcessing[currentItem.imageUrl] === undefined) {
       this.currentlyProcessing[currentItem.imageUrl] = new Promise((resolve, reject) => {
         // process more items concurrently if we can
         if (this.canProcess) this.processQueue();
-
-        // function to call when done processing this item
-        // this will reduce the processing number
-        // then will execute this function again to process any remaining items
-        const done = () => {
-          this.processing--;
-          this.processQueue();
-
-          if (this.currentlyProcessing[currentItem.imageUrl] !== undefined) {
-            delete this.currentlyProcessing[currentItem.imageUrl];
-          }
-        };
-
-        const error = (e) => {
-          currentItem.reject();
-          this.throwError(e);
-          done();
-        };
 
         const localDir = this.file.cacheDirectory + this.config.cacheDirectoryName + '/';
         const fileName = this.createFileName(currentItem.imageUrl);
@@ -294,11 +296,13 @@ export class ImageLoader {
             }).catch((e) => {
               //Could not write image
               error(e);
+              reject(e);
             });
           },
           (e) => {
             //Could not get image via httpClient
             error(e);
+            reject(e);
           }
         );
       });
@@ -307,9 +311,22 @@ export class ImageLoader {
       this.currentlyProcessing[currentItem.imageUrl].then(() => {
         this.getCachedImagePath(currentItem.imageUrl).then((localUrl) => {
           currentItem.resolve(localUrl);
-        })
+        });
+        done();
+      },
+      (e) => {
+        error(e);
       });
     }
+  }
+
+  /**
+   * Search if the url is currently in the queue
+   * @param imageUrl {string} Image url to search
+   * @returns {boolean}
+   */
+  private currentlyInQueue(imageUrl: string) {
+    return this.queue.some(item => item.imageUrl === imageUrl);
   }
 
   /**


### PR DESCRIPTION
I was experiencing some problems loading the same url image more times than the concurrency allowed. 
In my app I have a list of items, more than 30 itens with images, and, for testing, I set the same image to all of them. 
What happend is that, in the first load (no cache), only a few items had their image loaded.

I've made some changes and I guess I got the fix, but I could test only on browser and android (device).

closes: #174