### PR TITLE
WIP: fix(image-loader): Wrong path with Ionic on Android

### DIFF
--- a/src/providers/image-loader.ts
+++ b/src/providers/image-loader.ts
@@ -104,10 +104,7 @@ export class ImageLoader {
   }
 
   private get isIonicWKWebView(): boolean {
-    return (
-      this.isWKWebView &&
-      (location.host === 'localhost:8080' || (<any>window).LiveReload)
-    );
+    return location.host === 'localhost:8080' || (<any>window).LiveReload;
   }
 
   private get isDevServer(): boolean {

--- a/src/providers/image-loader.ts
+++ b/src/providers/image-loader.ts
@@ -104,7 +104,10 @@ export class ImageLoader {
   }
 
   private get isIonicWKWebView(): boolean {
-    return location.host === 'localhost:8080' || (<any>window).LiveReload;
+    return (
+      (this.isWKWebView || this.platform.is('android')) &&
+      (location.host === 'localhost:8080' || (<any>window).LiveReload)
+    );
   }
 
   private get isDevServer(): boolean {


### PR DESCRIPTION
The check for `isWKWebView` is not needed in the `isIonicWKWebView` getter and leads to unexpected behavior when using Ionic on Android. 

Closes #183