### PR TITLE
Fix #230

### DIFF
--- a/src/providers/image-loader.ts
+++ b/src/providers/image-loader.ts
@@ -356,8 +356,8 @@ export class ImageLoader {
             error(e);
             reject(e);
           });
-        },
-      );
+        }
+      ).catch((e) => this.throwError(e));
     } else {
       // Prevented same Image from loading at the same time
       this.currentlyProcessing[currentItem.imageUrl].then(() => {


### PR DESCRIPTION
When the http request throws an error (eg. http status 403), there is no catch to the rejected promise, like mentionated in #230 